### PR TITLE
Data_pipeline bug fix

### DIFF
--- a/data/dataloader/athena.py
+++ b/data/dataloader/athena.py
@@ -46,7 +46,7 @@ class AthenaLoader(BaseLoader):
         return cursor
 
 
-    def load_data(self, schema, tables, staging_dir, pyathena_rc_path=None):
+    def load_data(self, schema, tables, staging_dir, pyathena_rc_path=None, **kwargs):
         """Creates connection to Athena database and returns all the tables there as a dict of Pandas dataframes
 
         Keyword Arguments:

--- a/data/processing/processing.py
+++ b/data/processing/processing.py
@@ -29,7 +29,7 @@ def get_dataframes_cached(loader_class=Covid19IndiaLoader, reload_data=False, la
     if reload_data:
         print("pulling from source")
         loader = loader_class()
-        dataframes = loader.load_data()
+        dataframes = loader.load_data(**kwargs)
     else:
         try:
             with open(picklefn, 'rb') as pickle_file:
@@ -90,7 +90,7 @@ def get_data(data_source, dataloading_params):
         else:
             return get_simulated_data_from_file(**dataloading_params)
 
-def get_custom_data_from_db(state='Maharashtra', district='Mumbai', granular_data=False, **kwargs):
+def get_custom_data_from_db(state='Maharashtra', district='Mumbai', **kwargs):
     print('fetching from athenadb...')
     label = kwargs.pop('label', None)
     dataframes = get_dataframes_cached(loader_class=AthenaLoader, label=label, **kwargs)


### PR DESCRIPTION
The kwargs are necessary to pass parameters to the dataloader. This is because for Athena we need to fetch data from different tables, and hence need to be aware of schema name, tables to fetch, etc.